### PR TITLE
remove the @jsx React.DOM pragma beacause its deprecated on React 0.12

### DIFF
--- a/countdown_timer.jsx
+++ b/countdown_timer.jsx
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var React = require('react');
 
 // Generic Countdown Timer UI component


### PR DESCRIPTION
I'm using the 0.13.3 version of React in my project. 
