### PR TITLE
Adding the ability to override class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ A timer component for React that counts down to zero for a specified number of m
  `initialTimeRemaining: Number`
  The time remaining for the countdown (in ms).
 
+`setClass: String (optional -- default: 'timer')`
+Override the 'timer' class with a custom class name
+
  `interval: Number (optional -- default: 1000ms)`
  The time between timer ticks (in ms).
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A timer component for React that counts down to zero for a specified number of m
  `initialTimeRemaining: Number`
  The time remaining for the countdown (in ms).
 
-`setClass: String (optional -- default: 'timer')`
-Override the 'timer' class with a custom class name
+ `className: String`
+  Custom class name to be applied to the timer
 
  `interval: Number (optional -- default: 1000ms)`
  The time between timer ticks (in ms).

--- a/countdown_timer.jsx
+++ b/countdown_timer.jsx
@@ -7,6 +7,8 @@ var React = require('react');
 // props:
 //   - initialTimeRemaining: Number
 //       The time remaining for the countdown (in ms).
+//   - className: String
+//       Custom class name to be applied to the timer
 //
 //   - interval: Number (optional -- default: 1000ms)
 //       The time between timer ticks (in ms).
@@ -126,7 +128,7 @@ var CountdownTimer = React.createClass({
     var timeRemaining = this.state.timeRemaining;
 
     return (
-      <div className={this.props.setClass || 'timer'}>
+      <div className={this.props.className}>
         {this.getFormattedTime(timeRemaining)}
       </div>
     );

--- a/countdown_timer.jsx
+++ b/countdown_timer.jsx
@@ -126,7 +126,7 @@ var CountdownTimer = React.createClass({
     var timeRemaining = this.state.timeRemaining;
 
     return (
-      <div className='timer'>
+      <div className={this.props.setClass || 'timer'}>
         {this.getFormattedTime(timeRemaining)}
       </div>
     );


### PR DESCRIPTION
Im using dynamically built css (babel-plugin-css-in-js) so the classnames are not predictable. Adding this would make it so I could style in code and pass along the class name for the timer.
