### PR TITLE
React Component Update

### DIFF
--- a/countdown_timer.jsx
+++ b/countdown_timer.jsx
@@ -1,8 +1,6 @@
-var React = require('react');
+import React, { Component, PropTypes } from 'react'
 
 // Generic Countdown Timer UI component
-//
-// https://github.com/uken/react-countdown-timer
 //
 // props:
 //   - initialTimeRemaining: Number
@@ -17,112 +15,110 @@ var React = require('react');
 //   - tickCallback(timeRemaining): Function (optional)
 //       A function to call each tick.
 //
-//   - completeCallback(): Function (optional)
-//       A function to call when the countdown completes.
-//
-var CountdownTimer = React.createClass({
-  displayName: 'CountdownTimer',
+export default class CountdownTimer extends Component {
 
-  propTypes: {
+  static propTypes = {
     initialTimeRemaining: React.PropTypes.number.isRequired,
     interval: React.PropTypes.number,
     formatFunc: React.PropTypes.func,
     tickCallback: React.PropTypes.func,
     completeCallback: React.PropTypes.func
-  },
+  }
 
-  getDefaultProps: function() {
+  getDefaultProps() {
     return {
       interval: 1000,
-      formatFunc: null,
-      tickCallback: null,
-      completeCallback: null
+      formatFunc: undefined,
+      tickCallback: undefined,
+      completeCallback: undefined,
     };
-  },
+  }
 
-  getInitialState: function() {
+  getInitialState() {
     // Normally an anti-pattern to use this.props in getInitialState,
     // but these are all initializations (not an anti-pattern).
     return {
       timeRemaining: this.props.initialTimeRemaining,
-      timeoutId: null,
-      prevTime: null
+      timeoutId: undefined,
+      prevTime: undefined
     };
-  },
+  }
 
-  componentDidMount: function() {
+  componentWillReceiveProps(newProps, oldProps) {
+    if (this.state.timeoutId) clearTimeout(this.state.timeoutId);
+    this.setState({ prevTime: undefined, timeRemaining: newProps.initialTimeRemaining });
+  }
+
+  componentDidMount() {
     this.tick();
-  },
+  }
 
-  componentWillReceiveProps: function(newProps) {
-    if (this.state.timeoutId) { clearTimeout(this.state.timeoutId); }
-    this.setState({prevTime: null, timeRemaining: newProps.initialTimeRemaining});
-  },
-
-  componentDidUpdate: function() {
+  componentDidUpdate(){
     if ((!this.state.prevTime) && this.state.timeRemaining > 0 && this.isMounted()) {
       this.tick();
     }
-  },
+  }
 
-  componentWillUnmount: function() {
+  componentWillUnmount() {
     clearTimeout(this.state.timeoutId);
-  },
+  }
 
-  tick: function() {
+  tick() {
+
     var currentTime = Date.now();
-    var dt = this.state.prevTime ? (currentTime - this.state.prevTime) : 0;
+    var dt = currentTime - this.state.prevTime || 0;
     var interval = this.props.interval;
 
     // correct for small variations in actual timeout time
     var timeRemainingInInterval = (interval - (dt % interval));
     var timeout = timeRemainingInInterval;
 
-    if (timeRemainingInInterval < (interval / 2.0)) {
+    if (timeRemainingInInterval < (interval / 2.0)){
       timeout += interval;
     }
 
     var timeRemaining = Math.max(this.state.timeRemaining - dt, 0);
     var countdownComplete = (this.state.prevTime && timeRemaining <= 0);
 
-    if (this.isMounted()) {
-      if (this.state.timeoutId) { clearTimeout(this.state.timeoutId); }
+    if (this.isMounted()){
+      if (this.state.timeoutId) clearTimeout(this.state.timeoutId);
       this.setState({
-        timeoutId: countdownComplete ? null : setTimeout(this.tick, timeout),
+        timeoutId: countdownComplete ? undefined: setTimeout(this.tick, timeout),
         prevTime: currentTime,
         timeRemaining: timeRemaining
       });
     }
 
     if (countdownComplete) {
-      if (this.props.completeCallback) { this.props.completeCallback(); }
+      if (this.props.completeCallback) { this.props.completeCallback() };
       return;
     }
 
     if (this.props.tickCallback) {
       this.props.tickCallback(timeRemaining);
     }
-  },
+  }
 
-  getFormattedTime: function(milliseconds) {
+
+  getFormattedTime(milliseconds) {
     if (this.props.formatFunc) {
       return this.props.formatFunc(milliseconds);
     }
 
     var totalSeconds = Math.round(milliseconds / 1000);
 
-    var seconds = parseInt(totalSeconds % 60, 10);
-    var minutes = parseInt(totalSeconds / 60, 10) % 60;
-    var hours = parseInt(totalSeconds / 3600, 10);
+    var seconds = parseInt(totalSeconds % 60);
+    var minutes = parseInt(totalSeconds / 60) % 60;
+    var hours = parseInt(totalSeconds / 3600);
 
     seconds = seconds < 10 ? '0' + seconds : seconds;
     minutes = minutes < 10 ? '0' + minutes : minutes;
     hours = hours < 10 ? '0' + hours : hours;
 
     return hours + ':' + minutes + ':' + seconds;
-  },
+  }
 
-  render: function() {
+  render() {
     var timeRemaining = this.state.timeRemaining;
 
     return (
@@ -131,6 +127,4 @@ var CountdownTimer = React.createClass({
       </div>
     );
   }
-});
-
-module.exports = CountdownTimer;
+}


### PR DESCRIPTION
This change is to update the current countdown-timer to extend React Component. This is a future proofing solution to aid the use of ES6 classes. Facebook recommends the deprecation of ReactClass, I suggest we follow suit.

Also fixes errors that the current implementation has. The following are listed below.

1) When adding props to component, passing them results in the timer restarting due to colliding logic in `componentWillReceiveProps`

2) Misuse of the constructor (as per @rloomba implementation)

-- I believe that although this adds the use of es6, it's necessary as an update to the current branch since the current state is basically unusable by any visitors using up to date libraries (most people I would presume).
